### PR TITLE
Refactor Request and Response classes

### DIFF
--- a/lib/shipwire.rb
+++ b/lib/shipwire.rb
@@ -1,5 +1,6 @@
 require 'deep_merge/rails_compat'
 require 'faraday'
+require 'faraday_middleware'
 require 'recursive_open_struct'
 
 require 'shipwire/version'

--- a/lib/shipwire/api.rb
+++ b/lib/shipwire/api.rb
@@ -1,22 +1,7 @@
 module Shipwire
   class Api
-    def request(method, path, options = {})
-      response = Response.new
-
-      begin
-        response.response = Request.new.
-          method(method).
-          path(path).
-          payload(options[:payload] || {}).
-          params(options[:params] || {}).
-          send
-      rescue Faraday::ConnectionFailed
-        response.api_errors << 'Unable to connect to Shipwire'
-      rescue Faraday::TimeoutError
-        response.api_errors << 'Shipwire connection timeout'
-      end
-
-      response
+    def request(method, path, body: {}, params: {})
+      Request.send(method: method, path: path, body: body, params: params)
     end
   end
 end

--- a/lib/shipwire/orders.rb
+++ b/lib/shipwire/orders.rb
@@ -4,16 +4,16 @@ module Shipwire
       request(:get, 'orders', params: params)
     end
 
-    def create(payload)
-      request(:post, 'orders', payload: payload)
+    def create(body)
+      request(:post, 'orders', body: body)
     end
 
     def find(id, params = {})
       request(:get, "orders/#{id}/trackings", params: params)
     end
 
-    def update(id, payload, params = {})
-      request(:put, "orders/#{id}", payload: payload, params: params)
+    def update(id, body, params = {})
+      request(:put, "orders/#{id}", body: body, params: params)
     end
 
     def cancel(id)

--- a/lib/shipwire/products.rb
+++ b/lib/shipwire/products.rb
@@ -4,47 +4,44 @@ module Shipwire
       request(:get, 'products', params: params_runner(params))
     end
 
-    def create(payload)
-      request(:post, 'products', payload: payload_runner(payload))
+    def create(body)
+      request(:post, 'products', body: body_runner(body))
     end
 
     def find(id)
       request(:get, "products/#{id}")
     end
 
-    def update(id, payload)
-      request(:put, "products/#{id}", payload: payload_runner(payload))
+    def update(id, body)
+      request(:put, "products/#{id}", body: body_runner(body))
     end
 
     def retire(id)
-      request(:post, 'products/retire', payload: retire_object(id))
+      request(:post, 'products/retire', body: retire_object(id))
     end
     alias_method :remove, :retire
     alias_method :delete, :retire
 
     protected
 
-    def product_classification; end
+    def product_classification
+      {}
+    end
 
     private
 
     def params_runner(params)
-      abridge(params)
+      with_product_classification(params)
     end
 
-    def payload_runner(payload)
-      [payload].flatten.each_with_object([]) do |item, pl|
-        pl << abridge(item)
+    def body_runner(body)
+      [body].flatten.each_with_object([]) do |item, pl|
+        pl << with_product_classification(item)
       end
     end
 
-    def abridge(payload)
-      classification = product_classification || {}
-
-      data          = RecursiveOpenStruct.new(payload).to_h
-      data_override = RecursiveOpenStruct.new(classification).to_h
-
-      data.deeper_merge(data_override)
+    def with_product_classification(body)
+      body.merge(product_classification)
     end
 
     def retire_object(obj)

--- a/lib/shipwire/rate.rb
+++ b/lib/shipwire/rate.rb
@@ -1,7 +1,7 @@
 module Shipwire
   class Rate < Api
-    def find(payload)
-      request(:post, 'rate', payload: payload)
+    def find(body)
+      request(:post, 'rate', body: body)
     end
   end
 end

--- a/lib/shipwire/receivings.rb
+++ b/lib/shipwire/receivings.rb
@@ -4,16 +4,16 @@ module Shipwire
       request(:get, 'receivings', params: params)
     end
 
-    def create(payload)
-      request(:post, 'receivings', payload: payload)
+    def create(body)
+      request(:post, 'receivings', body: body)
     end
 
     def find(id, params = {})
       request(:get, "receivings/#{id}", params: params)
     end
 
-    def update(id, payload, params = {})
-      request(:put, "receivings/#{id}", payload: payload, params: params)
+    def update(id, body, params = {})
+      request(:put, "receivings/#{id}", body: body, params: params)
     end
 
     def cancel(id)

--- a/lib/shipwire/response.rb
+++ b/lib/shipwire/response.rb
@@ -2,84 +2,61 @@ require 'json'
 
 module Shipwire
   class Response
-    attr_accessor :shipwire_errors,
-                  :shipwire_warnings,
-                  :api_errors,
-                  :response
+    attr_reader :error_summary, :validation_errors, :warnings, :body
 
-    def initialize
-      @shipwire_errors   = []
-      @shipwire_warnings = []
-      @api_errors        = []
-      @response          = nil
+    def initialize(underlying_response: nil, error_summary: nil)
+      @error_summary = error_summary
+
+      @validation_errors = []
+      @warnings = []
+
+      if underlying_response
+        load_response(underlying_response)
+      end
     end
 
     def ok?
-      errors.empty?
+      !has_error_summary? && !has_validation_errors?
     end
 
-    def errors?
-      api_errors? || shipwire_errors?
-    end
-    alias_method :has_errors?, :errors?
-
-    def errors
-      api_errors + shipwire_errors
+    def has_error_summary?
+      !error_summary.nil?
     end
 
-    def api_errors?
-      !api_errors.empty?
-    end
-    alias_method :has_api_errors?, :api_errors?
-
-    def shipwire_errors?
-      !shipwire_errors.empty?
-    end
-    alias_method :has_shipwire_errors?, :shipwire_errors?
-
-    def warnings?
-      !shipwire_warnings.empty?
-    end
-    alias_method :has_warnings?, :warnings?
-
-    def warnings
-      shipwire_warnings
+    def has_validation_errors?
+      !validation_errors.empty?
     end
 
-    def response=(payload)
-      json = JSON.parse(payload.body)
-
-      @response = RecursiveOpenStruct.new(json, recurse_over_arrays: true)
-
-      populate_errors
-      populate_warnings
+    def has_warnings?
+      !warnings.empty?
     end
 
     private
 
-    def populate_warnings
-      [*response.warnings].each { |item| shipwire_warnings << item.message }
-    end
-
-    def populate_errors
-      populate_status_errors
-
-      populate_response_errors
+    def load_response(response)
+      @body = JSON.parse(response.body)
+      @warnings = parse_warnings_from(body)
+      @error_summary = parse_error_summary_from(body)
+      @validation_errors = parse_validation_errors_from(body)
     end
 
     # Errors because of a 40x or 50x error
-    def populate_status_errors
-      if /^[45]+/.match(response.status.to_s)
-        shipwire_errors << response.message
+    def parse_error_summary_from(body)
+      if (400..599).include?(body['status']) && body.key?('message')
+        body['message']
+      else
+        nil
       end
     end
 
     # Errors specified in Shipwire response body
-    def populate_response_errors
-      [*response.errors].each do |item|
-        message = item.is_a?(RecursiveOpenStruct) ? item.message : item
+    def parse_validation_errors_from(body)
+      body.fetch('errors', {})
+    end
 
-        shipwire_errors << message
+    def parse_warnings_from(body)
+      body.fetch('warnings', []).map do |warning|
+        warning.fetch('message')
       end
     end
   end

--- a/lib/shipwire/returns.rb
+++ b/lib/shipwire/returns.rb
@@ -4,8 +4,8 @@ module Shipwire
       request(:get, 'returns', params: params)
     end
 
-    def create(payload)
-      request(:post, 'returns', payload: payload)
+    def create(body)
+      request(:post, 'returns', body: body)
     end
 
     def find(id, params = {})

--- a/lib/shipwire/webhooks.rb
+++ b/lib/shipwire/webhooks.rb
@@ -4,16 +4,16 @@ module Shipwire
       request(:get, 'webhooks')
     end
 
-    def create(payload)
-      request(:post, 'webhooks', payload: payload)
+    def create(body)
+      request(:post, 'webhooks', body: body)
     end
 
     def find(id)
       request(:get, "webhooks/#{id}")
     end
 
-    def update(id, payload)
-      request(:put, "webhooks/#{id}", payload: payload)
+    def update(id, body)
+      request(:put, "webhooks/#{id}", body: body)
     end
 
     def remove(id)

--- a/shipwire.gemspec
+++ b/shipwire.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "deep_merge", "~> 1.0.0"
   spec.add_dependency "faraday", "~> 0.9.1"
+  spec.add_dependency "faraday_middleware", "~> 0.10.0"
   spec.add_dependency "recursive-open-struct", "~> 0.6.4"
 
   spec.add_development_dependency "rspec",  "~> 3.2.0"

--- a/spec/features/access_spec.rb
+++ b/spec/features/access_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe "General access", type: :feature, vcr: true do
 
     it "raises an error" do
       VCR.use_cassette("credentials_missing") do
-        request = Shipwire::Secret.new.list
+        response = Shipwire::Secret.new.list
 
-        expect(request.errors?).to be_truthy
-        expect(request.errors).to include(
+        expect(response.ok?).to be_falsy
+        expect(response.error_summary).to eq(
           'Please include a valid Authorization header (Basic)'
         )
       end
@@ -27,10 +27,10 @@ RSpec.describe "General access", type: :feature, vcr: true do
 
     it "raises an error" do
       VCR.use_cassette("credentials_incorrect") do
-        request = Shipwire::Secret.new.list
+        response = Shipwire::Secret.new.list
 
-        expect(request.errors?).to be_truthy
-        expect(request.errors).to include(
+        expect(response.ok?).to be_falsy
+        expect(response.error_summary).to eq(
           'Please include a valid Authorization header (Basic)'
         )
       end
@@ -41,10 +41,10 @@ RSpec.describe "General access", type: :feature, vcr: true do
     before { Shipwire.configuration.endpoint = 'https://api.fake.shipwire.com' }
 
     it "raises an error" do
-      request = Shipwire::Secret.new.list
+      response = Shipwire::Secret.new.list
 
-      expect(request.errors?).to be_truthy
-      expect(request.errors).to include 'Unable to connect to Shipwire'
+      expect(response.ok?).to be_falsy
+      expect(response.error_summary).to eq 'Unable to connect to Shipwire'
     end
   end
 
@@ -52,10 +52,10 @@ RSpec.describe "General access", type: :feature, vcr: true do
     before { Shipwire.configuration.timeout = 0.0001 }
 
     it "raises an error" do
-      request = Shipwire::Secret.new.list
+      response = Shipwire::Secret.new.list
 
-      expect(request.errors?).to be_truthy
-      expect(request.errors).to include 'Shipwire connection timeout'
+      expect(response.ok?).to be_falsy
+      expect(response.error_summary).to eq 'Shipwire connection timeout'
     end
   end
 end

--- a/spec/features/product_types_spec.rb
+++ b/spec/features/product_types_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe "Product", type: :feature, vcr: true do
         context "without params" do
           it "is successful" do
             VCR.use_cassette("products_#{product_type}_list") do
-              request = product_class.new.list
+              response = product_class.new.list
 
-              expect(request.ok?).to be_truthy
+              expect(response.ok?).to be_truthy
             end
           end
         end
@@ -23,11 +23,11 @@ RSpec.describe "Product", type: :feature, vcr: true do
         context "with params" do
           it "is successful" do
             VCR.use_cassette("products_#{product_type}_list_with_params") do
-              request = product_class.new.list(
+              response = product_class.new.list(
                 sku: "TEST-PRODUCT"
               )
 
-              expect(request.ok?).to be_truthy
+              expect(response.ok?).to be_truthy
             end
           end
         end
@@ -43,20 +43,21 @@ RSpec.describe "Product", type: :feature, vcr: true do
         context "find" do
           it "is successful" do
             VCR.use_cassette("product_#{product_type}_find") do
-              product_id = product.response.resource.items.first.resource.id
+              product_id =
+                product.body["resource"]["items"].first["resource"]["id"]
 
-              request = product_class.new.find(product_id)
+              response = product_class.new.find(product_id)
 
-              expect(request.ok?).to be_truthy
+              expect(response.ok?).to be_truthy
             end
           end
 
           it "fails when id does not exist" do
             VCR.use_cassette("product_#{product_type}_find_fail") do
-              request = product_class.new.find(0)
+              response = product_class.new.find(0)
 
-              expect(request.errors?).to be_truthy
-              expect(request.errors).to include 'Product not found.'
+              expect(response.ok?).to be_falsy
+              expect(response.error_summary).to eq 'Product not found.'
             end
           end
         end
@@ -64,15 +65,16 @@ RSpec.describe "Product", type: :feature, vcr: true do
         context "update" do
           it "is successful" do
             VCR.use_cassette("product_#{product_type}_update") do
-              product_id = product.response.resource.items.first.resource.id
+              product_id =
+                product.body["resource"]["items"].first["resource"]["id"]
 
               payload = payload(product_type).deeper_merge!(
                 description: "Super awesome description"
               )
 
-              request = product_class.new.update(product_id, payload)
+              response = product_class.new.update(product_id, payload)
 
-              expect(request.ok?).to be_truthy
+              expect(response.ok?).to be_truthy
             end
           end
 
@@ -82,10 +84,10 @@ RSpec.describe "Product", type: :feature, vcr: true do
                 description: "Super awesome description"
               )
 
-              request = product_class.new.update(0, payload)
+              response = product_class.new.update(0, payload)
 
-              expect(request.errors?).to be_truthy
-              expect(request.errors).to include 'Product not found.'
+              expect(response.ok?).to be_falsy
+              expect(response.error_summary).to eq 'Product not found.'
             end
           end
         end
@@ -94,11 +96,12 @@ RSpec.describe "Product", type: :feature, vcr: true do
           context "with string passed" do
             it "is successful" do
               VCR.use_cassette("product_#{product_type}_retire_id") do
-                product_id = product.response.resource.items.first.resource.id
+                product_id =
+                  product.body["resource"]["items"].first["resource"]["id"]
 
-                request = product_class.new.retire(product_id)
+                response = product_class.new.retire(product_id)
 
-                expect(request.ok?).to be_truthy
+                expect(response.ok?).to be_truthy
               end
             end
           end
@@ -106,11 +109,12 @@ RSpec.describe "Product", type: :feature, vcr: true do
           context "with array passed" do
             it "is successful" do
               VCR.use_cassette("product_#{product_type}_retire_id") do
-                product_id = product.response.resource.items.first.resource.id
+                product_id =
+                  product.body["resource"]["items"].first["resource"]["id"]
 
-                request = product_class.new.retire([product_id, 0])
+                response = product_class.new.retire([product_id, 0])
 
-                expect(request.ok?).to be_truthy
+                expect(response.ok?).to be_truthy
               end
             end
           end
@@ -118,9 +122,9 @@ RSpec.describe "Product", type: :feature, vcr: true do
           context "when product does not exist" do
             it "is successful" do
               VCR.use_cassette("product_#{product_type}_retire_nonexistent") do
-                request = product_class.new.retire(0)
+                response = product_class.new.retire(0)
 
-                expect(request.ok?).to be_truthy
+                expect(response.ok?).to be_truthy
               end
             end
           end

--- a/spec/features/rate_spec.rb
+++ b/spec/features/rate_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe "Rate", type: :feature, vcr: true do
   context "find" do
     it "is successful with existing items" do
       VCR.use_cassette("rate_find") do
-        request = Shipwire::Rate.new.find(payload)
+        response = Shipwire::Rate.new.find(payload)
 
-        expect(request.ok?).to be_truthy
-        expect(request.response.resource.rates.count).to be >= 1
+        expect(response.ok?).to be_truthy
+        expect(response.body["resource"]["rates"].count).to be >= 1
       end
     end
 
@@ -16,10 +16,12 @@ RSpec.describe "Rate", type: :feature, vcr: true do
         bad_payload = payload
         bad_payload[:order][:items][0][:sku] = 'FAKE-PRODUCT'
 
-        request = Shipwire::Rate.new.find(bad_payload)
+        response = Shipwire::Rate.new.find(bad_payload)
 
-        expect(request.errors?).to be_truthy
-        expect(request.errors).to include "unknown SKU 'FAKE-PRODUCT'"
+        expect(response.ok?).to be_falsy
+        expect(response.validation_errors.first).to include(
+          "message" => "unknown SKU 'FAKE-PRODUCT'"
+        )
       end
     end
 

--- a/spec/features/receivings_spec.rb
+++ b/spec/features/receivings_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe "Receivings", type: :feature, vcr: true do
     context "without params" do
       it "is successful" do
         VCR.use_cassette("receivings_list") do
-          request = Shipwire::Receivings.new.list
+          response = Shipwire::Receivings.new.list
 
-          expect(request.ok?).to be_truthy
+          expect(response.ok?).to be_truthy
         end
       end
     end
@@ -20,11 +20,11 @@ RSpec.describe "Receivings", type: :feature, vcr: true do
     context "using params" do
       it "is successful" do
         VCR.use_cassette("receivings_list_with_params") do
-          request = Shipwire::Receivings.new.list(
+          response = Shipwire::Receivings.new.list(
             status: "canceled"
           )
 
-          expect(request.ok?).to be_truthy
+          expect(response.ok?).to be_truthy
         end
       end
     end
@@ -41,11 +41,12 @@ RSpec.describe "Receivings", type: :feature, vcr: true do
       context "without params" do
         it "is successful" do
           VCR.use_cassette("receiving_find") do
-            receiving_id = receiving.response.resource.items.first.resource.id
+            receiving_id =
+              receiving.body["resource"]["items"].first["resource"]["id"]
 
-            request = Shipwire::Receivings.new.find(receiving_id)
+            response = Shipwire::Receivings.new.find(receiving_id)
 
-            expect(request.ok?).to be_truthy
+            expect(response.ok?).to be_truthy
           end
         end
       end
@@ -53,22 +54,23 @@ RSpec.describe "Receivings", type: :feature, vcr: true do
       context "using params" do
         it "is successful" do
           VCR.use_cassette("receiving_find_with_params") do
-            receiving_id = receiving.response.resource.items.first.resource.id
+            receiving_id =
+              receiving.body["resource"]["items"].first["resource"]["id"]
 
-            request = Shipwire::Receivings.new.find(receiving_id,
+            response = Shipwire::Receivings.new.find(receiving_id,
                                                     expand: "holds")
 
-            expect(request.ok?).to be_truthy
+            expect(response.ok?).to be_truthy
           end
         end
       end
 
       it "fails when id does not exist" do
         VCR.use_cassette("receiving_find_fail") do
-          request = Shipwire::Receivings.new.find(0)
+          response = Shipwire::Receivings.new.find(0)
 
-          expect(request.errors?).to be_truthy
-          expect(request.errors).to include 'Receiving Order not found.'
+          expect(response.ok?).to be_falsy
+          expect(response.error_summary).to eq 'Receiving Order not found.'
         end
       end
     end
@@ -77,15 +79,16 @@ RSpec.describe "Receivings", type: :feature, vcr: true do
       context "without params" do
         it "is successful" do
           VCR.use_cassette("receiving_update") do
-            receiving_id = receiving.response.resource.items.first.resource.id
+            receiving_id =
+              receiving.body["resource"]["items"].first["resource"]["id"]
 
             payload_updates = { shipFrom: { email: FFaker::Internet.email } }
             payload_update  = payload.deeper_merge(payload_updates)
 
-            request = Shipwire::Receivings.new.update(receiving_id,
+            response = Shipwire::Receivings.new.update(receiving_id,
                                                       payload_update)
 
-            expect(request.ok?).to be_truthy
+            expect(response.ok?).to be_truthy
           end
         end
       end
@@ -93,16 +96,17 @@ RSpec.describe "Receivings", type: :feature, vcr: true do
       context "using params" do
         it "is successful" do
           VCR.use_cassette("receiving_update_with_params") do
-            receiving_id = receiving.response.resource.items.first.resource.id
+            receiving_id =
+              receiving.body["resource"]["items"].first["resource"]["id"]
 
             payload_updates = { shipFrom: { email: FFaker::Internet.email } }
             payload_update  = payload.deeper_merge(payload_updates)
 
-            request = Shipwire::Receivings.new.update(receiving_id,
+            response = Shipwire::Receivings.new.update(receiving_id,
                                                       payload_update,
                                                       expand: "all")
 
-            expect(request.ok?).to be_truthy
+            expect(response.ok?).to be_truthy
           end
         end
       end
@@ -112,10 +116,10 @@ RSpec.describe "Receivings", type: :feature, vcr: true do
           payload_updates = { shipFrom: { email: FFaker::Internet.email } }
           payload_update  = payload.deeper_merge(payload_updates)
 
-          request = Shipwire::Receivings.new.update(0, payload_update)
+          response = Shipwire::Receivings.new.update(0, payload_update)
 
-          expect(request.errors?).to be_truthy
-          expect(request.errors).to include(
+          expect(response.ok?).to be_falsy
+          expect(response.error_summary).to eq(
             "Order ID not detected. Please make a POST if you wish to create "\
             "an order."
           )
@@ -126,19 +130,20 @@ RSpec.describe "Receivings", type: :feature, vcr: true do
     context "labels_cancel" do
       it "is successful" do
         VCR.use_cassette("receiving_cancel_label") do
-          receiving_id = receiving.response.resource.items.first.resource.id
+          receiving_id =
+            receiving.body["resource"]["items"].first["resource"]["id"]
 
-          request = Shipwire::Receivings.new.labels_cancel(receiving_id)
+          response = Shipwire::Receivings.new.labels_cancel(receiving_id)
 
-          expect(request.ok?).to be_truthy
+          expect(response.ok?).to be_truthy
         end
       end
 
       it "is successful even when id does not exist" do
         VCR.use_cassette("receiving_cancel_label_nonexistent") do
-          request = Shipwire::Receivings.new.labels_cancel(0)
+          response = Shipwire::Receivings.new.labels_cancel(0)
 
-          expect(request.ok?).to be_truthy
+          expect(response.ok?).to be_truthy
         end
       end
     end
@@ -147,11 +152,12 @@ RSpec.describe "Receivings", type: :feature, vcr: true do
       context "without params" do
         it "is successful" do
           VCR.use_cassette("receiving_holds") do
-            receiving_id = receiving.response.resource.items.first.resource.id
+            receiving_id =
+              receiving.body["resource"]["items"].first["resource"]["id"]
 
-            request = Shipwire::Receivings.new.holds(receiving_id)
+            response = Shipwire::Receivings.new.holds(receiving_id)
 
-            expect(request.ok?).to be_truthy
+            expect(response.ok?).to be_truthy
           end
         end
       end
@@ -159,22 +165,23 @@ RSpec.describe "Receivings", type: :feature, vcr: true do
       context "using params" do
         it "is successful" do
           VCR.use_cassette("receiving_holds_with_params") do
-            receiving_id = receiving.response.resource.items.first.resource.id
+            receiving_id =
+              receiving.body["resource"]["items"].first["resource"]["id"]
 
-            request = Shipwire::Receivings.new.holds(receiving_id,
+            response = Shipwire::Receivings.new.holds(receiving_id,
                                                      includeCleared: 0)
 
-            expect(request.ok?).to be_truthy
+            expect(response.ok?).to be_truthy
           end
         end
       end
 
       it "fails when id does not exist" do
         VCR.use_cassette("receiving_holds_fail") do
-          request = Shipwire::Receivings.new.holds(0)
+          response = Shipwire::Receivings.new.holds(0)
 
-          expect(request.errors?).to be_truthy
-          expect(request.errors).to include 'Receiving Order not found.'
+          expect(response.ok?).to be_falsy
+          expect(response.error_summary).to eq 'Receiving Order not found.'
         end
       end
     end
@@ -182,20 +189,21 @@ RSpec.describe "Receivings", type: :feature, vcr: true do
     context "instructions_recipients" do
       it "is successful" do
         VCR.use_cassette("receiving_instructions_recipients") do
-          receiving_id = receiving.response.resource.items.first.resource.id
+          receiving_id =
+            receiving.body["resource"]["items"].first["resource"]["id"]
 
-          request = Shipwire::Receivings.new.instructions(receiving_id)
+          response = Shipwire::Receivings.new.instructions(receiving_id)
 
-          expect(request.ok?).to be_truthy
+          expect(response.ok?).to be_truthy
         end
       end
 
       it "fails when id does not exist" do
         VCR.use_cassette("receiving_instructions_recipients_fail") do
-          request = Shipwire::Receivings.new.instructions(0)
+          response = Shipwire::Receivings.new.instructions(0)
 
-          expect(request.errors?).to be_truthy
-          expect(request.errors).to include 'Receiving Order not found.'
+          expect(response.ok?).to be_falsy
+          expect(response.error_summary).to eq 'Receiving Order not found.'
         end
       end
     end
@@ -203,20 +211,21 @@ RSpec.describe "Receivings", type: :feature, vcr: true do
     context "items" do
       it "is successful" do
         VCR.use_cassette("receiving_items") do
-          receiving_id = receiving.response.resource.items.first.resource.id
+          receiving_id =
+            receiving.body["resource"]["items"].first["resource"]["id"]
 
-          request = Shipwire::Receivings.new.items(receiving_id)
+          response = Shipwire::Receivings.new.items(receiving_id)
 
-          expect(request.ok?).to be_truthy
+          expect(response.ok?).to be_truthy
         end
       end
 
       it "fails when id does not exist" do
         VCR.use_cassette("receiving_items_fail") do
-          request = Shipwire::Receivings.new.items(0)
+          response = Shipwire::Receivings.new.items(0)
 
-          expect(request.errors?).to be_truthy
-          expect(request.errors).to include 'Receiving Order not found.'
+          expect(response.ok?).to be_falsy
+          expect(response.error_summary).to eq 'Receiving Order not found.'
         end
       end
     end
@@ -224,20 +233,21 @@ RSpec.describe "Receivings", type: :feature, vcr: true do
     context "shipments" do
       it "is successful" do
         VCR.use_cassette("receiving_shipments") do
-          receiving_id = receiving.response.resource.items.first.resource.id
+          receiving_id =
+            receiving.body["resource"]["items"].first["resource"]["id"]
 
-          request = Shipwire::Receivings.new.shipments(receiving_id)
+          response = Shipwire::Receivings.new.shipments(receiving_id)
 
-          expect(request.ok?).to be_truthy
+          expect(response.ok?).to be_truthy
         end
       end
 
       it "fails when id does not exist" do
         VCR.use_cassette("receiving_shipments_fail") do
-          request = Shipwire::Receivings.new.shipments(0)
+          response = Shipwire::Receivings.new.shipments(0)
 
-          expect(request.errors?).to be_truthy
-          expect(request.errors).to include 'Receiving Order not found.'
+          expect(response.ok?).to be_falsy
+          expect(response.error_summary).to eq 'Receiving Order not found.'
         end
       end
     end
@@ -245,20 +255,21 @@ RSpec.describe "Receivings", type: :feature, vcr: true do
     context "trackings" do
       it "is successful" do
         VCR.use_cassette("receiving_tracking") do
-          receiving_id = receiving.response.resource.items.first.resource.id
+          receiving_id =
+            receiving.body["resource"]["items"].first["resource"]["id"]
 
-          request = Shipwire::Receivings.new.trackings(receiving_id)
+          response = Shipwire::Receivings.new.trackings(receiving_id)
 
-          expect(request.ok?).to be_truthy
+          expect(response.ok?).to be_truthy
         end
       end
 
       it "fails when id does not exist" do
         VCR.use_cassette("receiving_tracking_fail") do
-          request = Shipwire::Receivings.new.trackings(0)
+          response = Shipwire::Receivings.new.trackings(0)
 
-          expect(request.errors?).to be_truthy
-          expect(request.errors).to include 'Receiving Order not found.'
+          expect(response.ok?).to be_falsy
+          expect(response.error_summary).to eq 'Receiving Order not found.'
         end
       end
     end
@@ -266,20 +277,21 @@ RSpec.describe "Receivings", type: :feature, vcr: true do
     context "cancel" do
       it "is successful" do
         VCR.use_cassette("receiving_cancel") do
-          receiving_id = receiving.response.resource.items.first.resource.id
+          receiving_id =
+            receiving.body["resource"]["items"].first["resource"]["id"]
 
-          request = Shipwire::Receivings.new.cancel(receiving_id)
+          response = Shipwire::Receivings.new.cancel(receiving_id)
 
-          expect(request.ok?).to be_truthy
+          expect(response.ok?).to be_truthy
         end
       end
 
       it "fails when id does not exist" do
         VCR.use_cassette("receiving_cancel") do
-          request = Shipwire::Receivings.new.cancel(0)
+          response = Shipwire::Receivings.new.cancel(0)
 
-          expect(request.errors?).to be_truthy
-          expect(request.errors).to include 'Receiving not found'
+          expect(response.ok?).to be_falsy
+          expect(response.error_summary).to eq 'Receiving not found'
         end
       end
     end

--- a/spec/features/returns_spec.rb
+++ b/spec/features/returns_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe "Returns", type: :feature, vcr: true do
     context "without params" do
       it "is successful" do
         VCR.use_cassette("returns_list") do
-          request = Shipwire::Returns.new.list
+          response = Shipwire::Returns.new.list
 
-          expect(request.ok?).to be_truthy
+          expect(response.ok?).to be_truthy
         end
       end
     end
@@ -15,11 +15,11 @@ RSpec.describe "Returns", type: :feature, vcr: true do
     context "using params" do
       it "is successful" do
         VCR.use_cassette("returns_list_with_params") do
-          request = Shipwire::Returns.new.list(
+          response = Shipwire::Returns.new.list(
             status: "canceled"
           )
 
-          expect(request.ok?).to be_truthy
+          expect(response.ok?).to be_truthy
         end
       end
     end
@@ -52,7 +52,7 @@ RSpec.describe "Returns", type: :feature, vcr: true do
           }
         )
 
-        order_id = order.response.resource.items.first.resource.id
+        order_id = order.body["resource"]["items"].first["resource"]["id"]
 
         # There is an issue with returns. You can't create an order, then
         # immediately return it. This is the functionality that a test would be
@@ -78,11 +78,12 @@ RSpec.describe "Returns", type: :feature, vcr: true do
       context "without params" do
         it "is successful" do
           VCR.use_cassette("return_find") do
-            return_id = return_order.response.resource.items.first.resource.id
+            return_id =
+              return_order.body["resource"]["items"].first["resource"]["id"]
 
-            request = Shipwire::Returns.new.find(return_id)
+            response = Shipwire::Returns.new.find(return_id)
 
-            expect(request.ok?).to be_truthy
+            expect(response.ok?).to be_truthy
           end
         end
       end
@@ -90,21 +91,22 @@ RSpec.describe "Returns", type: :feature, vcr: true do
       context "using params" do
         it "is successful" do
           VCR.use_cassette("return_find_with_params") do
-            return_id = return_order.response.resource.items.first.resource.id
+            return_id =
+              return_order.body["resource"]["items"].first["resource"]["id"]
 
-            request = Shipwire::Returns.new.find(return_id, expand: "items")
+            response = Shipwire::Returns.new.find(return_id, expand: "items")
 
-            expect(request.ok?).to be_truthy
+            expect(response.ok?).to be_truthy
           end
         end
       end
 
       it "fails when id does not exist" do
         VCR.use_cassette("return_find_fail") do
-          request = Shipwire::Returns.new.find(0)
+          response = Shipwire::Returns.new.find(0)
 
-          expect(request.errors?).to be_truthy
-          expect(request.errors).to include 'Receiving Order not found.'
+          expect(response.ok?).to be_falsy
+          expect(response.error_summary).to eq 'Receiving Order not found.'
         end
       end
     end
@@ -113,11 +115,12 @@ RSpec.describe "Returns", type: :feature, vcr: true do
       context "without params" do
         it "is successful" do
           VCR.use_cassette("return_holds") do
-            return_id = return_order.response.resource.items.first.resource.id
+            return_id =
+              return_order.body["resource"]["items"].first["resource"]["id"]
 
-            request = Shipwire::Returns.new.holds(return_id)
+            response = Shipwire::Returns.new.holds(return_id)
 
-            expect(request.ok?).to be_truthy
+            expect(response.ok?).to be_truthy
           end
         end
       end
@@ -125,21 +128,22 @@ RSpec.describe "Returns", type: :feature, vcr: true do
       context "using params" do
         it "is successful" do
           VCR.use_cassette("return_holds_with_params") do
-            return_id = return_order.response.resource.items.first.resource.id
+            return_id =
+              return_order.body["resource"]["items"].first["resource"]["id"]
 
-            request = Shipwire::Returns.new.holds(return_id, includeCleared: 0)
+            response = Shipwire::Returns.new.holds(return_id, includeCleared: 0)
 
-            expect(request.ok?).to be_truthy
+            expect(response.ok?).to be_truthy
           end
         end
       end
 
       it "fails when id does not exist" do
         VCR.use_cassette("return_holds_fail") do
-          request = Shipwire::Returns.new.holds(0)
+          response = Shipwire::Returns.new.holds(0)
 
-          expect(request.errors?).to be_truthy
-          expect(request.errors).to include 'Receiving Order not found.'
+          expect(response.ok?).to be_falsy
+          expect(response.error_summary).to eq 'Receiving Order not found.'
         end
       end
     end
@@ -147,20 +151,21 @@ RSpec.describe "Returns", type: :feature, vcr: true do
     context "items" do
       it "is successful" do
         VCR.use_cassette("return_items") do
-          return_id = return_order.response.resource.items.first.resource.id
+          return_id =
+            return_order.body["resource"]["items"].first["resource"]["id"]
 
-          request = Shipwire::Returns.new.items(return_id)
+          response = Shipwire::Returns.new.items(return_id)
 
-          expect(request.ok?).to be_truthy
+          expect(response.ok?).to be_truthy
         end
       end
 
       it "fails when id does not exist" do
         VCR.use_cassette("return_items_fail") do
-          request = Shipwire::Returns.new.items(0)
+          response = Shipwire::Returns.new.items(0)
 
-          expect(request.errors?).to be_truthy
-          expect(request.errors).to include 'Receiving Order not found.'
+          expect(response.ok?).to be_falsy
+          expect(response.error_summary).to eq 'Receiving Order not found.'
         end
       end
     end
@@ -168,20 +173,21 @@ RSpec.describe "Returns", type: :feature, vcr: true do
     context "trackings" do
       it "is successful" do
         VCR.use_cassette("return_trackings") do
-          return_id = return_order.response.resource.items.first.resource.id
+          return_id =
+            return_order.body["resource"]["items"].first["resource"]["id"]
 
-          request = Shipwire::Returns.new.trackings(return_id)
+          response = Shipwire::Returns.new.trackings(return_id)
 
-          expect(request.ok?).to be_truthy
+          expect(response.ok?).to be_truthy
         end
       end
 
       it "fails when id does not exist" do
         VCR.use_cassette("return_trackings_fail") do
-          request = Shipwire::Returns.new.trackings(0)
+          response = Shipwire::Returns.new.trackings(0)
 
-          expect(request.errors?).to be_truthy
-          expect(request.errors).to include 'Receiving Order not found.'
+          expect(response.ok?).to be_falsy
+          expect(response.error_summary).to eq 'Receiving Order not found.'
         end
       end
     end
@@ -189,20 +195,21 @@ RSpec.describe "Returns", type: :feature, vcr: true do
     context "labels" do
       it "is successful" do
         VCR.use_cassette("return_labels") do
-          return_id = return_order.response.resource.items.first.resource.id
+          return_id =
+            return_order.body["resource"]["items"].first["resource"]["id"]
 
-          request = Shipwire::Returns.new.labels(return_id)
+          response = Shipwire::Returns.new.labels(return_id)
 
-          expect(request.ok?).to be_truthy
+          expect(response.ok?).to be_truthy
         end
       end
 
       it "fails when id does not exist" do
         VCR.use_cassette("return_labels_fail") do
-          request = Shipwire::Returns.new.labels(0)
+          response = Shipwire::Returns.new.labels(0)
 
-          expect(request.errors?).to be_truthy
-          expect(request.errors).to include 'Receiving Label not found.'
+          expect(response.ok?).to be_falsy
+          expect(response.error_summary).to eq 'Receiving Label not found.'
         end
       end
     end
@@ -210,20 +217,21 @@ RSpec.describe "Returns", type: :feature, vcr: true do
     context "cancel" do
       it "is successful" do
         VCR.use_cassette("return_cancel") do
-          return_id = return_order.response.resource.items.first.resource.id
+          return_id =
+            return_order.body["resource"]["items"].first["resource"]["id"]
 
-          request = Shipwire::Returns.new.cancel(return_id)
+          response = Shipwire::Returns.new.cancel(return_id)
 
-          expect(request.ok?).to be_truthy
+          expect(response.ok?).to be_truthy
         end
       end
 
       it "fails when id does not exist" do
         VCR.use_cassette("return_cancel_fail") do
-          request = Shipwire::Returns.new.cancel(0)
+          response = Shipwire::Returns.new.cancel(0)
 
-          expect(request.errors?).to be_truthy
-          expect(request.errors).to include 'Return Order not found.'
+          expect(response.ok?).to be_falsy
+          expect(response.error_summary).to eq 'Return Order not found.'
         end
       end
     end

--- a/spec/features/secret_spec.rb
+++ b/spec/features/secret_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe "Secret", type: :feature, vcr: true do
   context "list" do
     it "is successful" do
       VCR.use_cassette("secret_list") do
-        request = Shipwire::Secret.new.list
+        response = Shipwire::Secret.new.list
 
-        expect(request.ok?).to be_truthy
+        expect(response.ok?).to be_truthy
       end
     end
   end
@@ -21,11 +21,11 @@ RSpec.describe "Secret", type: :feature, vcr: true do
     context "find" do
       it "is successful" do
         VCR.use_cassette("secret_find") do
-          secret_id = secret.response.resource.id
+          secret_id = secret.body["resource"]["id"]
 
-          request = Shipwire::Secret.new.find(secret_id)
+          response = Shipwire::Secret.new.find(secret_id)
 
-          expect(request.ok?).to be_truthy
+          expect(response.ok?).to be_truthy
         end
       end
 
@@ -34,10 +34,10 @@ RSpec.describe "Secret", type: :feature, vcr: true do
           # ID 0 returns data for an existing secret at index 0 instead of a
           # not found. Shipwire considers this an unintended feature or shortcut
           # rather than a bug. So use 1 instead of 0.
-          request = Shipwire::Secret.new.find(1)
+          response = Shipwire::Secret.new.find(1)
 
-          expect(request.errors?).to be_truthy
-          expect(request.errors).to include 'Not found'
+          expect(response.ok?).to be_falsy
+          expect(response.error_summary).to eq 'Not found'
         end
       end
     end
@@ -45,11 +45,11 @@ RSpec.describe "Secret", type: :feature, vcr: true do
     context "remove" do
       it "is successful" do
         VCR.use_cassette("secret_remove") do
-          secret_id = secret.response.resource.id
+          secret_id = secret.body["resource"]["id"]
 
-          request = Shipwire::Secret.new.remove(secret_id)
+          response = Shipwire::Secret.new.remove(secret_id)
 
-          expect(request.ok?).to be_truthy
+          expect(response.ok?).to be_truthy
         end
       end
     end

--- a/spec/features/stock_spec.rb
+++ b/spec/features/stock_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe "Stock", type: :feature, vcr: true do
     context "without params" do
       it "is successful" do
         VCR.use_cassette("stock_without_params") do
-          request = Shipwire::Stock.new.list
+          response = Shipwire::Stock.new.list
 
-          expect(request.ok?).to be_truthy
+          expect(response.ok?).to be_truthy
         end
       end
     end
@@ -15,11 +15,11 @@ RSpec.describe "Stock", type: :feature, vcr: true do
     context "with params" do
       it "is successful" do
         VCR.use_cassette("stock_with_params") do
-          request = Shipwire::Stock.new.list(
+          response = Shipwire::Stock.new.list(
             sku: "TEST-PRODUCT"
           )
 
-          expect(request.ok?).to be_truthy
+          expect(response.ok?).to be_truthy
         end
       end
     end
@@ -29,11 +29,11 @@ RSpec.describe "Stock", type: :feature, vcr: true do
         # Returns a successful result. There is just no records in the result
         # set because they were all filtered out. There are no errors.
         VCR.use_cassette("stock_with_params_no_sku") do
-          request = Shipwire::Stock.new.list(
+          response = Shipwire::Stock.new.list(
             sku: "FAKE-PRODUCT"
           )
 
-          expect(request.ok?).to be_truthy
+          expect(response.ok?).to be_truthy
         end
       end
     end

--- a/spec/features/webhooks_spec.rb
+++ b/spec/features/webhooks_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe "Webhooks", type: :feature, vcr: true do
   context "list" do
     it "is successful" do
       VCR.use_cassette("webhooks_list") do
-        request = Shipwire::Webhooks.new.list
+        response = Shipwire::Webhooks.new.list
 
-        expect(request.ok?).to be_truthy
+        expect(response.ok?).to be_truthy
       end
     end
   end
@@ -28,13 +28,13 @@ RSpec.describe "Webhooks", type: :feature, vcr: true do
     context "create" do
       it "fails with non-https callback URL" do
         VCR.use_cassette("webhooks_create_insecure") do
-          request = Shipwire::Webhooks.new.create(
+          response = Shipwire::Webhooks.new.create(
             topic: webhook_topic,
             url:   "http://www.reddit.com/"
           )
 
-          expect(request.errors?).to be_truthy
-          expect(request.errors).to include('Invalid URL')
+          expect(response.ok?).to be_falsy
+          expect(response.validation_errors).to include('Invalid URL')
         end
       end
     end
@@ -42,20 +42,20 @@ RSpec.describe "Webhooks", type: :feature, vcr: true do
     context "find" do
       it "is successful" do
         VCR.use_cassette("webhooks_find") do
-          webhook_id = webhook.response.resource.items.first.resource.id
+          webhook_id = webhook.body["resource"]["items"].first["resource"]["id"]
 
-          request = Shipwire::Webhooks.new.find(webhook_id)
+          response = Shipwire::Webhooks.new.find(webhook_id)
 
-          expect(request.ok?).to be_truthy
+          expect(response.ok?).to be_truthy
         end
       end
 
       it "fails when id does not exist" do
         VCR.use_cassette("webhooks_find_fail") do
-          request = Shipwire::Webhooks.new.find(0)
+          response = Shipwire::Webhooks.new.find(0)
 
-          expect(request.errors?).to be_truthy
-          expect(request.errors).to include('Subscription not found.')
+          expect(response.ok?).to be_falsy
+          expect(response.error_summary).to eq 'Subscription not found.'
         end
       end
     end
@@ -63,16 +63,16 @@ RSpec.describe "Webhooks", type: :feature, vcr: true do
     context "update" do
       it "is successful" do
         VCR.use_cassette("webhooks_update") do
-          webhook_id = webhook.response.resource.items.first.resource.id
+          webhook_id = webhook.body["resource"]["items"].first["resource"]["id"]
 
           payload = {
             topic: webhook_topic,
             url:   webhook_url_update
           }
 
-          request = Shipwire::Webhooks.new.update(webhook_id, payload)
+          response = Shipwire::Webhooks.new.update(webhook_id, payload)
 
-          expect(request.ok?).to be_truthy
+          expect(response.ok?).to be_truthy
         end
       end
 
@@ -83,10 +83,10 @@ RSpec.describe "Webhooks", type: :feature, vcr: true do
             url:   webhook_url_update
           }
 
-          request = Shipwire::Webhooks.new.update(0, payload)
+          response = Shipwire::Webhooks.new.update(0, payload)
 
-          expect(request.errors?).to be_truthy
-          expect(request.response.message).to eq "Invalid request"
+          expect(response.ok?).to be_falsy
+          expect(response.error_summary).to eq "Invalid request"
         end
       end
     end
@@ -94,11 +94,11 @@ RSpec.describe "Webhooks", type: :feature, vcr: true do
     context "remove" do
       it "is successful" do
         VCR.use_cassette("webhooks_remove") do
-          webhook_id = webhook.response.resource.items.first.resource.id
+          webhook_id = webhook.body["resource"]["items"].first["resource"]["id"]
 
-          request = Shipwire::Webhooks.new.remove(webhook_id)
+          response = Shipwire::Webhooks.new.remove(webhook_id)
 
-          expect(request.ok?).to be_truthy
+          expect(response.ok?).to be_truthy
         end
       end
     end


### PR DESCRIPTION
This commit is rather large, but it all centers around cleaning up some
of the internals and making things generally easier to work with.
- Make some changes around the Request class:
  - Have Request take options for the various pieces of the request as
    keyword arguments. I felt that defining "setter" methods that
    weren't named like setter methods (i.e. with an `=` on the end) was
    a little unconventional.
  - Rename `payload` to `body`, since "request body" is a more common
    term for the kind of thing this is describing.
  - Move exception handling from the `request` method to the Request
    class, and have the Request class return a Response object, since I
    felt that both things are the responsibility of the Request class.
  - Remove `request_` from methods in the Request class, since that's
    implied, and rename some of the methods to be a little more
    understandable.
- Simplify Response class:
  - Don't wrap the response body in a RecursiveOpenStruct. This gem
    makes iterating over the body more complicated as
    RecursiveOpenStruct does not seem to support Enumerable. Instead,
    stick to a plain Ruby hash.
  - Don't combine all of the possible errors that a response could have
    into one method, since they're all of different data types: the
    `message` property is a string, whereas the `errors` property could
    be an array or a hash. Instead, provide a way to access these errors
    individually.
  - Tweak some of the method names so that they're more readable.
