### PR TITLE
Add error_report to Response

### DIFF
--- a/lib/shipwire/response.rb
+++ b/lib/shipwire/response.rb
@@ -31,6 +31,22 @@ module Shipwire
       !warnings.empty?
     end
 
+    def error_report
+      report_lines = []
+
+      if has_error_summary?
+        report_lines << 'Error summary:'
+        report_lines << error_summary
+      end
+
+      if has_validation_errors?
+        report_lines << 'Validation errors:'
+        report_lines << validation_errors.pretty_inspect
+      end
+
+      report_lines.join("\n")
+    end
+
     private
 
     def load_response(response)

--- a/spec/unit/shipwire/response_spec.rb
+++ b/spec/unit/shipwire/response_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+RSpec.describe Shipwire::Response do
+  describe '#error_report' do
+    context 'when the response has an error summary' do
+      it 'includes it in the returned text' do
+        body = JSON.generate(
+          'status' => 500,
+          'message' => 'Something really bad happened'
+        )
+        underlying_response = double(:response, body: body)
+        response = described_class.new(
+          underlying_response: underlying_response
+        )
+
+        expected_error_summary = <<-REPORT.rstrip
+Error summary:
+Something really bad happened
+REPORT
+        expect(response.error_report).to include(expected_error_summary)
+      end
+    end
+
+    context 'when the response has validation errors' do
+      it 'includes it in the returned text' do
+        body = JSON.generate(
+          'errors' => {
+            'SKU-1' => { 'some' => 'really really really long error' },
+            'SKU-2' => { 'another' => 'error' }
+          }
+        )
+        underlying_response = double(:response, body: body)
+        response = described_class.new(
+          underlying_response: underlying_response
+        )
+
+        expected_validation_errors = <<-REPORT.rstrip
+Validation errors:
+{"SKU-1"=>{"some"=>"really really really long error"},
+ "SKU-2"=>{"another"=>"error"}}
+REPORT
+        expect(response.error_report).to include(expected_validation_errors)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This method gives us a way to pretty-print errors that are contained in
the response. This is useful in Oracle when we are registering webhooks
-- we want to raise an exception if a request is unsuccessful and
include the response errors in that exception message.
